### PR TITLE
PYMT-1610: Trusted Proxies

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,6 +26,6 @@
         <env name="ENV_TRUE1" value='"true"'/>
         <env name="ENV_TRUE2" value="(true)"/>
         <env name="TRUSTED_PROXIES" value="127.0.0.1,REMOTE_ADDR"/>
-        <env name="TRUSTED_PROXIES_HEADER" value="aws"/>
+        <env name="TRUSTED_PROXIES_HEADER" value="HEADER_X_FORWARDED_AWS_ELB"/>
     </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,5 +25,7 @@
         <env name="ENV_NULL2" value="(null)"/>
         <env name="ENV_TRUE1" value='"true"'/>
         <env name="ENV_TRUE2" value="(true)"/>
+        <env name="TRUSTED_PROXIES" value="127.0.0.1,REMOTE_ADDR"/>
+        <env name="TRUSTED_PROXIES_HEADER" value="aws"/>
     </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,7 +25,7 @@
         <env name="ENV_NULL2" value="(null)"/>
         <env name="ENV_TRUE1" value='"true"'/>
         <env name="ENV_TRUE2" value="(true)"/>
-        <env name="TRUSTED_PROXIES" value="127.0.0.1,REMOTE_ADDR"/>
+        <env name="TRUSTED_PROXIES" value="127.0.0.1,10.0.0.0/8"/>
         <env name="TRUSTED_PROXIES_HEADER" value="HEADER_X_FORWARDED_AWS_ELB"/>
     </php>
 </phpunit>

--- a/src/Bridge/Laravel/Providers/RequestServiceProvider.php
+++ b/src/Bridge/Laravel/Providers/RequestServiceProvider.php
@@ -44,11 +44,17 @@ final class RequestServiceProvider extends ServiceProvider
      */
     private function mapTrustedHeader(string $value): int
     {
-        $constant = \constant(
-            \sprintf('%s::%s', HttpRequest::class, $value)
-        );
+        $name = \sprintf('%s::%s', HttpRequest::class, $value);
 
-        if ($constant !== null) {
+        // @codeCoverageIgnoreStart
+        // Safety fallback, unable to alter environment values in externals to test.
+        if (\defined($name) === false) {
+            return HttpRequest::HEADER_X_FORWARDED_ALL;
+        }
+        // @codeCoverageIgnoreEnd
+
+        $constant = \constant($name);
+        if (\is_int($constant)) {
             return $constant;
         }
 

--- a/src/Bridge/Laravel/Providers/RequestServiceProvider.php
+++ b/src/Bridge/Laravel/Providers/RequestServiceProvider.php
@@ -28,10 +28,26 @@ final class RequestServiceProvider extends ServiceProvider
             // Set proxy list
             HttpRequest::setTrustedProxies(
                 \explode(',', $env->get('TRUSTED_PROXIES') ?? ''),
-                HttpRequest::HEADER_X_FORWARDED_ALL
+                $this->mapTrustedHeader($env->get('TRUSTED_PROXIES_HEADER') ?? '')
             );
 
             return $this->app->make(Request::class);
         });
+    }
+
+    /**
+     * Maps the trusted header string value to integer.
+     *
+     * @param string $value
+     *
+     * @return int
+     */
+    private function mapTrustedHeader(string $value): int
+    {
+        if (\strtolower($value) === 'aws') {
+            return HttpRequest::HEADER_X_FORWARDED_AWS_ELB;
+        }
+
+        return HttpRequest::HEADER_X_FORWARDED_ALL;
     }
 }

--- a/src/Bridge/Laravel/Providers/RequestServiceProvider.php
+++ b/src/Bridge/Laravel/Providers/RequestServiceProvider.php
@@ -44,8 +44,12 @@ final class RequestServiceProvider extends ServiceProvider
      */
     private function mapTrustedHeader(string $value): int
     {
-        if (\strtolower($value) === 'aws') {
-            return HttpRequest::HEADER_X_FORWARDED_AWS_ELB;
+        $constant = \constant(
+            \sprintf('%s::%s', HttpRequest::class, $value)
+        );
+
+        if ($constant !== null) {
+            return $constant;
         }
 
         return HttpRequest::HEADER_X_FORWARDED_ALL;

--- a/src/Bridge/Laravel/Providers/RequestServiceProvider.php
+++ b/src/Bridge/Laravel/Providers/RequestServiceProvider.php
@@ -52,6 +52,9 @@ final class RequestServiceProvider extends ServiceProvider
             return $constant;
         }
 
+        // @codeCoverageIgnoreStart
+        // Safety fallback, unable to alter environment values in externals to test.
         return HttpRequest::HEADER_X_FORWARDED_ALL;
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/tests/Bridge/Laravel/Providers/RequestServiceProviderTest.php
+++ b/tests/Bridge/Laravel/Providers/RequestServiceProviderTest.php
@@ -5,6 +5,7 @@ namespace Tests\EoneoPay\Externals\Bridge\Laravel\Providers;
 
 use EoneoPay\Externals\Bridge\Laravel\Providers\RequestServiceProvider;
 use EoneoPay\Externals\Request\Interfaces\RequestInterface;
+use Illuminate\Http\Request as HttpRequest;
 use Tests\EoneoPay\Externals\Stubs\Vendor\Illuminate\Contracts\Foundation\ApplicationStub;
 use Tests\EoneoPay\Externals\TestCase;
 
@@ -27,5 +28,8 @@ class RequestServiceProviderTest extends TestCase
 
         // Ensure services are bound
         self::assertInstanceOf(RequestInterface::class, $application->get(RequestInterface::class));
+
+        // Ensure the trusted proxy headers are set
+        self::assertSame(['127.0.0.1', 'REMOTE_ADDR'], HttpRequest::getTrustedProxies());
     }
 }

--- a/tests/Bridge/Laravel/Providers/RequestServiceProviderTest.php
+++ b/tests/Bridge/Laravel/Providers/RequestServiceProviderTest.php
@@ -18,6 +18,8 @@ class RequestServiceProviderTest extends TestCase
      * Test provider bind our request interface into container.
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) Static access to HttpRequest required to get proxies.
      */
     public function testRegister(): void
     {

--- a/tests/Bridge/Laravel/Providers/RequestServiceProviderTest.php
+++ b/tests/Bridge/Laravel/Providers/RequestServiceProviderTest.php
@@ -32,6 +32,7 @@ class RequestServiceProviderTest extends TestCase
         self::assertInstanceOf(RequestInterface::class, $application->get(RequestInterface::class));
 
         // Ensure the trusted proxy headers are set
-        self::assertSame(['127.0.0.1', 'REMOTE_ADDR'], HttpRequest::getTrustedProxies());
+        self::assertSame(['127.0.0.1', '10.0.0.0/8'], HttpRequest::getTrustedProxies());
+        self::assertSame(HttpRequest::HEADER_X_FORWARDED_AWS_ELB, HttpRequest::getTrustedHeaderSet());
     }
 }

--- a/tests/Bridge/Laravel/RequestTest.php
+++ b/tests/Bridge/Laravel/RequestTest.php
@@ -28,6 +28,7 @@ class RequestTest extends TestCase
         self::assertSame('127.0.0.1', $request->getClientIp());
 
         // Test proxy header is ignored if proxy isn't trusted
+        HttpRequest::setTrustedProxies(['10.0.0.0/24'], HttpRequest::HEADER_X_FORWARDED_ALL);
         $request = new Request(new HttpRequest([], [], [], [], [], [
             'HTTP_X_FORWARDED_FOR' => '192.168.10.10',
             'REMOTE_ADDR' => '127.0.0.1',
@@ -35,7 +36,7 @@ class RequestTest extends TestCase
         self::assertSame('127.0.0.1', $request->getClientIp());
 
         // Test reading from proxy works if proxy is set
-        HttpRequest::setTrustedProxies(['127.0.0.1/24'], HttpRequest::HEADER_X_FORWARDED_ALL);
+        HttpRequest::setTrustedProxies(['127.0.0.0/24'], HttpRequest::HEADER_X_FORWARDED_ALL);
         $request = new Request(new HttpRequest([], [], [], [], [], [
             'HTTP_X_FORWARDED_FOR' => '192.168.10.10',
             'REMOTE_ADDR' => '127.0.0.1',


### PR DESCRIPTION
This PR updates the request service provider, allowing the headers option of the `setTrustedProxies` to be set by environment.